### PR TITLE
Add option to specify change type in merge commit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,4 +3,4 @@
 Check off the following once completed and after creating the Pull Request:
 - [ ] New code has related tests to cover it
 - [ ] README.md is up to date with the accurate documentation to reflect the changes in this Pull Request
-- [ ] `#minor`, `#major`, or `#patch` has been entered at least once into a commit message in the set
+- [ ] `#minor`, `#major`, or `#patch` has been entered at least once into a commit message in the set or in the merge commit


### PR DESCRIPTION
Signed-off-by: Zack Koppert <zkoppert@github.com>

This adds text to allow for version type (ie. `#major`) to be specified in the merge commit.

Check off the following once completed and after creating the Pull Request:
- [x] New code has related tests to cover it
- [x] README.md is up to date with the accurate documentation to reflect the changes in this Pull Request
- [x] `#minor`, `#major`, or `#patch` has been entered at least once into a commit message in the set
